### PR TITLE
Feature/3 pacttype conversion trait

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -14,11 +14,9 @@
 //!
 //! The pact bytecode interpreter
 //!
+pub mod type_cast;
 pub mod types;
 use types::PactType;
-
-#[cfg(feature = "std")]
-pub mod type_cast;
 
 // OpCode masks
 const OP_MASK: u8 = 0b0011_1111;

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -17,6 +17,7 @@
 pub mod types;
 use types::PactType;
 
+#[cfg(feature = "std")]
 pub mod type_cast;
 
 // OpCode masks

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -17,11 +17,13 @@
 pub mod types;
 use types::PactType;
 
+pub mod type_cast;
+
 // OpCode masks
 const OP_MASK: u8 = 0b0011_1111;
 
 /// Interpret some pact byte code (`source`) with input data registers (`input_data`) and
-/// user data registers (`user_data`).  
+/// user data registers (`user_data`).
 /// Returns a boolean indicating whether the pact contract was validated or not,
 /// An InterpErr is returned on a runtime error e.g. malformed byte code, missing data, invalid OpCode etc.
 pub fn interpret(
@@ -74,7 +76,7 @@ pub enum InterpErr {
 
 /// A pact instruction code
 ///
-/// Big Endian OpCodes  
+/// Big Endian OpCodes
 /// - 6 bit OpCode index
 /// - 1 bit reserved
 /// - 1 bit reserved
@@ -166,7 +168,7 @@ impl OpCode {
     }
 }
 
-/// Convert an OpCode into its u8 index.  
+/// Convert an OpCode into its u8 index.
 /// It does not encode any following parameters
 impl Into<u8> for OpCode {
     fn into(self) -> u8 {
@@ -226,7 +228,7 @@ fn eval_conjunction(op: OpCode, lhs: bool, rhs: bool) -> Result<bool, InterpErr>
 /// The pact interpreter
 /// It evaluates `OpCode`s maintaining the state of the current contract execution
 /// Uses the rust type system to encode state, see: https://hoverbear.org/2016/10/12/rust-state-machine-pattern/
-/// States provide transformations into other valid states and failure cases.  
+/// States provide transformations into other valid states and failure cases.
 #[cfg_attr(feature = "std", derive(Debug))]
 pub struct Interpreter<'a> {
     state: State<'a>,

--- a/src/interpreter/type_cast.rs
+++ b/src/interpreter/type_cast.rs
@@ -14,29 +14,106 @@ trait AnyTryInto<'a>: Sized {
     fn any_try_into(value: &'a dyn Any) -> Result<Self, PactConversionErr>;
 }
 
-/// A default implementation to return UnknownType err by default using specialization feature
-impl<'a, T> AnyTryInto<'a> for T {
-    default fn any_try_into(_value: &'a dyn Any) -> Result<Self, PactConversionErr> {
-        Err(PactConversionErr::UnknownType)
-    }
-}
-
+/// AnyTryInto implementation for PactType
 impl<'a> AnyTryInto<'a> for PactType<'a> {
     fn any_try_into(value: &'a dyn Any) -> Result<PactType<'a>, PactConversionErr> {
-        if let Some(number) = value.downcast_ref::<i8>() {
-            if *number < 0 {
-                return Err(PactConversionErr::NegativeInteger);
+        // TODO: refactor the below repetiion using macros
+        // Signed integer type casting into PactType
+        if value.is::<i8>()
+            || value.is::<i16>()
+            || value.is::<i32>()
+            || value.is::<i64>()
+            || value.is::<i128>()
+        {
+            if let Some(number) = value.downcast_ref::<i8>() {
+                if *number < 0 {
+                    return Err(PactConversionErr::NegativeInteger);
+                }
+                if let Ok(n) = u64::try_from(*number) {
+                    return Ok(PactType::Numeric(Numeric(n)));
+                }
             }
-            if let Ok(n) = u64::try_from(*number) {
-                return Ok(PactType::Numeric(Numeric(n)));
+            if let Some(number) = value.downcast_ref::<i16>() {
+                if *number < 0 {
+                    return Err(PactConversionErr::NegativeInteger);
+                }
+                if let Ok(n) = u64::try_from(*number) {
+                    return Ok(PactType::Numeric(Numeric(n)));
+                }
+            }
+            if let Some(number) = value.downcast_ref::<i32>() {
+                if *number < 0 {
+                    return Err(PactConversionErr::NegativeInteger);
+                }
+                if let Ok(n) = u64::try_from(*number) {
+                    return Ok(PactType::Numeric(Numeric(n)));
+                }
+            }
+            if let Some(number) = value.downcast_ref::<i64>() {
+                if *number < 0 {
+                    return Err(PactConversionErr::NegativeInteger);
+                }
+                if let Ok(n) = u64::try_from(*number) {
+                    return Ok(PactType::Numeric(Numeric(n)));
+                }
+            }
+            if let Some(number) = value.downcast_ref::<i128>() {
+                if *number < 0 {
+                    return Err(PactConversionErr::NegativeInteger);
+                }
+                if *number > std::u64::MAX as i128 {
+                    return Err(PactConversionErr::Overflow);
+                }
+                if let Ok(n) = u64::try_from(*number) {
+                    return Ok(PactType::Numeric(Numeric(n)));
+                }
             }
         }
-        // ... the above repeated for all integer types
 
-        if let Some(string) = value.downcast_ref::<&str>() {
-            return Ok(PactType::StringLike(StringLike(&*string.as_bytes())));
+        // Unsigned integer type casting into PactType
+        if value.is::<u8>()
+            || value.is::<u16>()
+            || value.is::<u32>()
+            || value.is::<u64>()
+            || value.is::<u128>()
+        {
+            if let Some(number) = value.downcast_ref::<u8>() {
+                if let Ok(n) = u64::try_from(*number) {
+                    return Ok(PactType::Numeric(Numeric(n)));
+                }
+            }
+            if let Some(number) = value.downcast_ref::<u16>() {
+                if let Ok(n) = u64::try_from(*number) {
+                    return Ok(PactType::Numeric(Numeric(n)));
+                }
+            }
+            if let Some(number) = value.downcast_ref::<u32>() {
+                if let Ok(n) = u64::try_from(*number) {
+                    return Ok(PactType::Numeric(Numeric(n)));
+                }
+            }
+            if let Some(number) = value.downcast_ref::<u64>() {
+                return Ok(PactType::Numeric(Numeric(*number)));
+            }
+            if let Some(number) = value.downcast_ref::<u128>() {
+                if *number > std::u64::MAX as u128 {
+                    return Err(PactConversionErr::Overflow);
+                }
+                if let Ok(n) = u64::try_from(*number) {
+                    return Ok(PactType::Numeric(Numeric(n)));
+                }
+            }
         }
-        // ... the above repeated for all string-like types
+
+        // String-like type casting into PactType
+        if value.is::<&str>() || value.is::<String>() {
+            if let Some(string) = value.downcast_ref::<&str>() {
+                return Ok(PactType::StringLike(StringLike(&*string.as_bytes())));
+            }
+            if let Some(string) = value.downcast_ref::<String>() {
+                return Ok(PactType::StringLike(StringLike(string.as_bytes())));
+            }
+        }
 
         // Unhandled Type
         Err(PactConversionErr::UnknownType)
@@ -54,8 +131,24 @@ mod tests {
             Ok(PactType::Numeric(Numeric(0))),
         );
         assert_eq!(
-            PactType::any_try_into(&0_i128),
-            Err(PactConversionErr::UnknownType),
+            PactType::any_try_into(&1_i128),
+            Ok(PactType::Numeric(Numeric(1))),
+        );
+
+        // Assertion for negative integer
+        assert_eq!(
+            PactType::any_try_into(&-10_i8),
+            Err(PactConversionErr::NegativeInteger),
+        );
+
+        // Assertion for overflow
+        assert_eq!(
+            PactType::any_try_into(&(std::u64::MAX as i128 + 1)),
+            Err(PactConversionErr::Overflow),
+        );
+        assert_eq!(
+            PactType::any_try_into(&(std::u64::MAX as u128 + 2)),
+            Err(PactConversionErr::Overflow),
         );
     }
 
@@ -63,6 +156,14 @@ mod tests {
     fn it_converts_string() {
         assert_eq!(
             PactType::any_try_into(&"test"),
+            Ok(PactType::StringLike(StringLike(b"test"))),
+        );
+        assert_eq!(
+            PactType::any_try_into(&'a'.to_string()),
+            Ok(PactType::StringLike(StringLike(b"a"))),
+        );
+        assert_eq!(
+            PactType::any_try_into(&"test".to_string()),
             Ok(PactType::StringLike(StringLike(b"test"))),
         );
     }

--- a/src/interpreter/type_cast.rs
+++ b/src/interpreter/type_cast.rs
@@ -1,4 +1,4 @@
-use crate::types::{Numeric, PactType, StringLike};
+use crate::interpreter::types::{Numeric, PactType, StringLike};
 use std::any::Any;
 use std::convert::TryFrom;
 
@@ -10,7 +10,7 @@ pub enum PactConversionErr {
 }
 
 /// A catch-all conversion trait which tries to turn any given `value` into the implementing type
-trait AnyTryInto<'a>: Sized {
+pub trait AnyTryInto<'a>: Sized {
     fn any_try_into(value: &'a dyn Any) -> Result<Self, PactConversionErr>;
 }
 

--- a/src/interpreter/type_cast.rs
+++ b/src/interpreter/type_cast.rs
@@ -1,0 +1,69 @@
+use crate::types::{Numeric, PactType, StringLike};
+use std::any::Any;
+use std::convert::TryFrom;
+
+#[derive(Debug, PartialEq)]
+pub enum PactConversionErr {
+    NegativeInteger,
+    Overflow,
+    UnknownType,
+}
+
+/// A catch-all conversion trait which tries to turn any given `value` into the implementing type
+trait AnyTryInto<'a>: Sized {
+    fn any_try_into(value: &'a dyn Any) -> Result<Self, PactConversionErr>;
+}
+
+/// A default implementation to return UnknownType err by default using specialization feature
+impl<'a, T> AnyTryInto<'a> for T {
+    default fn any_try_into(_value: &'a dyn Any) -> Result<Self, PactConversionErr> {
+        Err(PactConversionErr::UnknownType)
+    }
+}
+
+impl<'a> AnyTryInto<'a> for PactType<'a> {
+    fn any_try_into(value: &'a dyn Any) -> Result<PactType<'a>, PactConversionErr> {
+        if let Some(number) = value.downcast_ref::<i8>() {
+            if *number < 0 {
+                return Err(PactConversionErr::NegativeInteger);
+            }
+            if let Ok(n) = u64::try_from(*number) {
+                return Ok(PactType::Numeric(Numeric(n)));
+            }
+        }
+        // ... the above repeated for all integer types
+
+        if let Some(string) = value.downcast_ref::<&str>() {
+            return Ok(PactType::StringLike(StringLike(&*string.as_bytes())));
+        }
+        // ... the above repeated for all string-like types
+
+        // Unhandled Type
+        Err(PactConversionErr::UnknownType)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_converts_numeric() {
+        assert_eq!(
+            PactType::any_try_into(&0_i8),
+            Ok(PactType::Numeric(Numeric(0))),
+        );
+        assert_eq!(
+            PactType::any_try_into(&0_i128),
+            Err(PactConversionErr::UnknownType),
+        );
+    }
+
+    #[test]
+    fn it_converts_string() {
+        assert_eq!(
+            PactType::any_try_into(&"test"),
+            Ok(PactType::StringLike(StringLike(b"test"))),
+        );
+    }
+}

--- a/src/interpreter/type_cast.rs
+++ b/src/interpreter/type_cast.rs
@@ -2,6 +2,7 @@ use crate::interpreter::types::{Numeric, PactType, StringLike};
 use core::any::Any;
 use core::convert::TryFrom;
 use std::string::String;
+use std::vec::Vec;
 
 #[derive(Debug, PartialEq)]
 pub enum PactConversionErr {
@@ -53,26 +54,64 @@ impl<'a> AnyTryInto<'a> for PactType<'a> {
         if let Some(string) = value.downcast_ref::<String>() {
             return Ok(PactType::StringLike(StringLike(string.as_bytes())));
         }
+        if let Some(string) = value.downcast_ref::<Vec<u8>>() {
+            return Ok(PactType::StringLike(StringLike(&*string)));
+        }
+
+        // Fixed hash type casting into PactType
+        if let Some(string) = value.downcast_ref::<[u8; 4]>() {
+            return Ok(PactType::StringLike(StringLike(&*string))); // H32
+        }
+        if let Some(string) = value.downcast_ref::<[u8; 8]>() {
+            return Ok(PactType::StringLike(StringLike(&*string))); // H64
+        }
+        if let Some(string) = value.downcast_ref::<[u8; 16]>() {
+            return Ok(PactType::StringLike(StringLike(&*string))); // H128
+        }
+        if let Some(string) = value.downcast_ref::<[u8; 20]>() {
+            return Ok(PactType::StringLike(StringLike(&*string))); // H160
+        }
+        if let Some(string) = value.downcast_ref::<[u8; 32]>() {
+            return Ok(PactType::StringLike(StringLike(&*string))); // H256
+        }
+        if let Some(string) = value.downcast_ref::<[u8; 33]>() {
+            return Ok(PactType::StringLike(StringLike(&*string))); // H264
+        }
+        if let Some(string) = value.downcast_ref::<[u8; 64]>() {
+            return Ok(PactType::StringLike(StringLike(&*string))); // H512
+        }
+        if let Some(string) = value.downcast_ref::<[u8; 65]>() {
+            return Ok(PactType::StringLike(StringLike(&*string))); // H520
+        }
+        if let Some(string) = value.downcast_ref::<[u8; 128]>() {
+            return Ok(PactType::StringLike(StringLike(&*string))); // H1024
+        }
+        if let Some(string) = value.downcast_ref::<[u8; 256]>() {
+            return Ok(PactType::StringLike(StringLike(&*string))); // H2048
+        }
 
         // Unhandled Type
         Err(PactConversionErr::UnknownType)
     }
 }
 
+#[rustfmt::skip]
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn it_converts_numeric() {
-        assert_eq!(
-            PactType::any_try_into(&0_u8),
-            Ok(PactType::Numeric(Numeric(0))),
-        );
-        assert_eq!(
-            PactType::any_try_into(&1_u128),
-            Ok(PactType::Numeric(Numeric(1))),
-        );
+        let tests = vec![
+            (PactType::any_try_into(&0_u8),   Ok(PactType::Numeric(Numeric(0)))),
+            (PactType::any_try_into(&1_u16),  Ok(PactType::Numeric(Numeric(1)))),
+            (PactType::any_try_into(&2_u32),  Ok(PactType::Numeric(Numeric(2)))),
+            (PactType::any_try_into(&3_u64),  Ok(PactType::Numeric(Numeric(3)))),
+            (PactType::any_try_into(&4_u128), Ok(PactType::Numeric(Numeric(4)))),
+        ];
+        for (lhs, rhs) in tests {
+            assert_eq!(lhs, rhs);
+        }
 
         // Assertion for overflow
         assert_eq!(
@@ -82,7 +121,7 @@ mod tests {
     }
 
     #[test]
-    fn it_converts_string() {
+    fn it_converts_string_like() {
         assert_eq!(
             PactType::any_try_into(&"test"),
             Ok(PactType::StringLike(StringLike(b"test"))),
@@ -95,5 +134,91 @@ mod tests {
             PactType::any_try_into(&"test".to_string()),
             Ok(PactType::StringLike(StringLike(b"test"))),
         );
+
+        let v: Vec<u8> = vec![116, 101, 115, 116];
+        assert_eq!(
+            PactType::any_try_into(&v),
+            Ok(PactType::StringLike(StringLike(b"test")))
+        );
+
+        // Assertion for fixed hash types
+        let h32 = b"0x01";
+        let h64 = b"0x012345";
+        let h128 = b"0x01234567891011";
+        let h160 = b"0x012345678910111213";
+        let h256 = b"0x012345678910111213141516171819";
+        let h264 = b"0x0123456789101112131415161718192";
+        let h512 = b"0x01234567891011121314151617181920212223242526272829303132333435";
+        let h520 = b"0x012345678910111213141516171819202122232425262728293031323334353";
+
+        let tests = vec![
+            (PactType::any_try_into(h32),  Ok(PactType::StringLike(StringLike(h32)))),
+            (PactType::any_try_into(h64),  Ok(PactType::StringLike(StringLike(h64)))),
+            (PactType::any_try_into(h128), Ok(PactType::StringLike(StringLike(h128)))),
+            (PactType::any_try_into(h160), Ok(PactType::StringLike(StringLike(h160)))),
+            (PactType::any_try_into(h256), Ok(PactType::StringLike(StringLike(h256)))),
+            (PactType::any_try_into(h264), Ok(PactType::StringLike(StringLike(h264)))),
+            (PactType::any_try_into(h512), Ok(PactType::StringLike(StringLike(h512)))),
+            (PactType::any_try_into(h520), Ok(PactType::StringLike(StringLike(h520)))),
+        ];
+        for (lhs, rhs) in tests {
+            assert_eq!(lhs, rhs);
+        }
+    }
+
+    #[test]
+    fn it_converts_numeric_associated_types() {
+        trait Foo {
+            type Number32;
+            type Number64;
+        }
+
+        struct Bar;
+
+        impl Foo for Bar {
+            type Number32 = u32;
+            type Number64 = u64;
+        }
+
+        let n32: <Bar as Foo>::Number32 = 10u32;
+        let n64: <Bar as Foo>::Number64 = 20u64;
+
+        let tests = vec![
+            (PactType::any_try_into(&n32), Ok(PactType::Numeric(Numeric(10)))),
+            (PactType::any_try_into(&n64), Ok(PactType::Numeric(Numeric(20)))),
+        ];
+        for (lhs, rhs) in tests {
+            assert_eq!(lhs, rhs);
+        }
+    }
+
+    #[test]
+    fn it_converts_string_like_associated_types() {
+        trait Foo {
+            type Ref;
+            type Vec;
+            type Str;
+        }
+
+        struct Bar;
+
+        impl Foo for Bar {
+            type Ref = &'static str;
+            type Vec = Vec<u8>;
+            type Str = String;
+        }
+
+        let s1: <Bar as Foo>::Ref = "test1";
+        let s2: <Bar as Foo>::Vec = vec![116, 101, 115, 116, 50];
+        let s3: <Bar as Foo>::Str = "test3".to_string();
+
+        let tests = vec![
+            (PactType::any_try_into(&s1), Ok(PactType::StringLike(StringLike(b"test1")))),
+            (PactType::any_try_into(&s2), Ok(PactType::StringLike(StringLike(b"test2")))),
+            (PactType::any_try_into(&s3), Ok(PactType::StringLike(StringLike(b"test3")))),
+        ];
+        for (lhs, rhs) in tests {
+            assert_eq!(lhs, rhs);
+        }
     }
 }

--- a/src/interpreter/type_cast.rs
+++ b/src/interpreter/type_cast.rs
@@ -21,30 +21,21 @@ impl<'a> AnyTryInto<'a> for PactType<'a> {
         // TODO: refactor the below repetiion using macros
         // Unsigned integer type casting into PactType
         if let Some(number) = value.downcast_ref::<u8>() {
-            if let Ok(n) = u64::try_from(*number) {
-                return Ok(PactType::Numeric(Numeric(n)));
-            }
+            return Ok(PactType::Numeric(Numeric(*number as u64)));
         }
         if let Some(number) = value.downcast_ref::<u16>() {
-            if let Ok(n) = u64::try_from(*number) {
-                return Ok(PactType::Numeric(Numeric(n)));
-            }
+            return Ok(PactType::Numeric(Numeric(*number as u64)));
         }
         if let Some(number) = value.downcast_ref::<u32>() {
-            if let Ok(n) = u64::try_from(*number) {
-                return Ok(PactType::Numeric(Numeric(n)));
-            }
+            return Ok(PactType::Numeric(Numeric(*number as u64)));
         }
         if let Some(number) = value.downcast_ref::<u64>() {
             return Ok(PactType::Numeric(Numeric(*number)));
         }
         if let Some(number) = value.downcast_ref::<u128>() {
-            if *number > core::u64::MAX as u128 {
-                return Err(PactConversionErr::Overflow);
-            }
-            if let Ok(n) = u64::try_from(*number) {
-                return Ok(PactType::Numeric(Numeric(n)));
-            }
+            return Ok(PactType::Numeric(Numeric(
+                u64::try_from(*number).map_err(|_| PactConversionErr::Overflow)?,
+            )));
         }
 
         // String-like type casting into PactType

--- a/src/interpreter/type_cast.rs
+++ b/src/interpreter/type_cast.rs
@@ -19,48 +19,39 @@ impl<'a> AnyTryInto<'a> for PactType<'a> {
     fn any_try_into(value: &'a dyn Any) -> Result<PactType<'a>, PactConversionErr> {
         // TODO: refactor the below repetiion using macros
         // Unsigned integer type casting into PactType
-        if value.is::<u8>()
-            || value.is::<u16>()
-            || value.is::<u32>()
-            || value.is::<u64>()
-            || value.is::<u128>()
-        {
-            if let Some(number) = value.downcast_ref::<u8>() {
-                if let Ok(n) = u64::try_from(*number) {
-                    return Ok(PactType::Numeric(Numeric(n)));
-                }
+        if let Some(number) = value.downcast_ref::<u8>() {
+            if let Ok(n) = u64::try_from(*number) {
+                return Ok(PactType::Numeric(Numeric(n)));
             }
-            if let Some(number) = value.downcast_ref::<u16>() {
-                if let Ok(n) = u64::try_from(*number) {
-                    return Ok(PactType::Numeric(Numeric(n)));
-                }
+        }
+        if let Some(number) = value.downcast_ref::<u16>() {
+            if let Ok(n) = u64::try_from(*number) {
+                return Ok(PactType::Numeric(Numeric(n)));
             }
-            if let Some(number) = value.downcast_ref::<u32>() {
-                if let Ok(n) = u64::try_from(*number) {
-                    return Ok(PactType::Numeric(Numeric(n)));
-                }
+        }
+        if let Some(number) = value.downcast_ref::<u32>() {
+            if let Ok(n) = u64::try_from(*number) {
+                return Ok(PactType::Numeric(Numeric(n)));
             }
-            if let Some(number) = value.downcast_ref::<u64>() {
-                return Ok(PactType::Numeric(Numeric(*number)));
+        }
+        if let Some(number) = value.downcast_ref::<u64>() {
+            return Ok(PactType::Numeric(Numeric(*number)));
+        }
+        if let Some(number) = value.downcast_ref::<u128>() {
+            if *number > core::u64::MAX as u128 {
+                return Err(PactConversionErr::Overflow);
             }
-            if let Some(number) = value.downcast_ref::<u128>() {
-                if *number > core::u64::MAX as u128 {
-                    return Err(PactConversionErr::Overflow);
-                }
-                if let Ok(n) = u64::try_from(*number) {
-                    return Ok(PactType::Numeric(Numeric(n)));
-                }
+            if let Ok(n) = u64::try_from(*number) {
+                return Ok(PactType::Numeric(Numeric(n)));
             }
         }
 
         // String-like type casting into PactType
-        if value.is::<&str>() || value.is::<String>() {
-            if let Some(string) = value.downcast_ref::<&str>() {
-                return Ok(PactType::StringLike(StringLike(&*string.as_bytes())));
-            }
-            if let Some(string) = value.downcast_ref::<String>() {
-                return Ok(PactType::StringLike(StringLike(string.as_bytes())));
-            }
+        if let Some(string) = value.downcast_ref::<&str>() {
+            return Ok(PactType::StringLike(StringLike(&*string.as_bytes())));
+        }
+        if let Some(string) = value.downcast_ref::<String>() {
+            return Ok(PactType::StringLike(StringLike(string.as_bytes())));
         }
 
         // Unhandled Type

--- a/src/interpreter/type_cast.rs
+++ b/src/interpreter/type_cast.rs
@@ -1,6 +1,7 @@
 use crate::interpreter::types::{Numeric, PactType, StringLike};
-use std::any::Any;
-use std::convert::TryFrom;
+use core::any::Any;
+use core::convert::TryFrom;
+use std::string::String;
 
 #[derive(Debug, PartialEq)]
 pub enum PactConversionErr {
@@ -43,7 +44,7 @@ impl<'a> AnyTryInto<'a> for PactType<'a> {
                 return Ok(PactType::Numeric(Numeric(*number)));
             }
             if let Some(number) = value.downcast_ref::<u128>() {
-                if *number > std::u64::MAX as u128 {
+                if *number > core::u64::MAX as u128 {
                     return Err(PactConversionErr::Overflow);
                 }
                 if let Ok(n) = u64::try_from(*number) {
@@ -84,7 +85,7 @@ mod tests {
 
         // Assertion for overflow
         assert_eq!(
-            PactType::any_try_into(&(std::u64::MAX as u128 + 2)),
+            PactType::any_try_into(&(core::u64::MAX as u128 + 2)),
             Err(PactConversionErr::Overflow),
         );
     }

--- a/src/interpreter/type_cast.rs
+++ b/src/interpreter/type_cast.rs
@@ -4,7 +4,6 @@ use std::convert::TryFrom;
 
 #[derive(Debug, PartialEq)]
 pub enum PactConversionErr {
-    NegativeInteger,
     Overflow,
     UnknownType,
 }
@@ -18,58 +17,6 @@ pub trait AnyTryInto<'a>: Sized {
 impl<'a> AnyTryInto<'a> for PactType<'a> {
     fn any_try_into(value: &'a dyn Any) -> Result<PactType<'a>, PactConversionErr> {
         // TODO: refactor the below repetiion using macros
-        // Signed integer type casting into PactType
-        if value.is::<i8>()
-            || value.is::<i16>()
-            || value.is::<i32>()
-            || value.is::<i64>()
-            || value.is::<i128>()
-        {
-            if let Some(number) = value.downcast_ref::<i8>() {
-                if *number < 0 {
-                    return Err(PactConversionErr::NegativeInteger);
-                }
-                if let Ok(n) = u64::try_from(*number) {
-                    return Ok(PactType::Numeric(Numeric(n)));
-                }
-            }
-            if let Some(number) = value.downcast_ref::<i16>() {
-                if *number < 0 {
-                    return Err(PactConversionErr::NegativeInteger);
-                }
-                if let Ok(n) = u64::try_from(*number) {
-                    return Ok(PactType::Numeric(Numeric(n)));
-                }
-            }
-            if let Some(number) = value.downcast_ref::<i32>() {
-                if *number < 0 {
-                    return Err(PactConversionErr::NegativeInteger);
-                }
-                if let Ok(n) = u64::try_from(*number) {
-                    return Ok(PactType::Numeric(Numeric(n)));
-                }
-            }
-            if let Some(number) = value.downcast_ref::<i64>() {
-                if *number < 0 {
-                    return Err(PactConversionErr::NegativeInteger);
-                }
-                if let Ok(n) = u64::try_from(*number) {
-                    return Ok(PactType::Numeric(Numeric(n)));
-                }
-            }
-            if let Some(number) = value.downcast_ref::<i128>() {
-                if *number < 0 {
-                    return Err(PactConversionErr::NegativeInteger);
-                }
-                if *number > std::u64::MAX as i128 {
-                    return Err(PactConversionErr::Overflow);
-                }
-                if let Ok(n) = u64::try_from(*number) {
-                    return Ok(PactType::Numeric(Numeric(n)));
-                }
-            }
-        }
-
         // Unsigned integer type casting into PactType
         if value.is::<u8>()
             || value.is::<u16>()
@@ -127,25 +74,15 @@ mod tests {
     #[test]
     fn it_converts_numeric() {
         assert_eq!(
-            PactType::any_try_into(&0_i8),
+            PactType::any_try_into(&0_u8),
             Ok(PactType::Numeric(Numeric(0))),
         );
         assert_eq!(
-            PactType::any_try_into(&1_i128),
+            PactType::any_try_into(&1_u128),
             Ok(PactType::Numeric(Numeric(1))),
         );
 
-        // Assertion for negative integer
-        assert_eq!(
-            PactType::any_try_into(&-10_i8),
-            Err(PactConversionErr::NegativeInteger),
-        );
-
         // Assertion for overflow
-        assert_eq!(
-            PactType::any_try_into(&(std::u64::MAX as i128 + 1)),
-            Err(PactConversionErr::Overflow),
-        );
         assert_eq!(
             PactType::any_try_into(&(std::u64::MAX as u128 + 2)),
             Err(PactConversionErr::Overflow),

--- a/src/interpreter/type_cast.rs
+++ b/src/interpreter/type_cast.rs
@@ -18,7 +18,7 @@ pub trait AnyTryInto<'a>: Sized {
 /// AnyTryInto implementation for PactType
 impl<'a> AnyTryInto<'a> for PactType<'a> {
     fn any_try_into(value: &'a dyn Any) -> Result<PactType<'a>, PactConversionErr> {
-        // TODO: refactor the below repetiion using macros
+        // TODO: refactor the below repetition using macros
         // Unsigned integer type casting into PactType
         if let Some(number) = value.downcast_ref::<u8>() {
             return Ok(PactType::Numeric(Numeric(*number as u64)));

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -14,6 +14,7 @@
 //!
 //! Primitive types in the pact interpreter.
 //!
+pub use crate::interpreter::type_cast::AnyTryInto;
 use bit_reverse::ParallelReverse;
 use std::vec::Vec;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,9 @@ pub mod interpreter;
 pub use interpreter::types;
 
 #[cfg(feature = "std")]
+pub use interpreter::type_cast;
+
+#[cfg(feature = "std")]
 pub mod compiler;
 
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![feature(specialization)]
 
 // 'std' is required for parser and compilation
 // interpreter can execute in `no_std` environment

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,6 @@ extern crate pest;
 extern crate pest_derive;
 
 pub mod interpreter;
-pub use interpreter::type_cast;
 pub use interpreter::types;
 
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,10 +26,8 @@ extern crate pest;
 extern crate pest_derive;
 
 pub mod interpreter;
-pub use interpreter::types;
-
-#[cfg(feature = "std")]
 pub use interpreter::type_cast;
+pub use interpreter::types;
 
 #[cfg(feature = "std")]
 pub mod compiler;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(specialization)]
 
 // 'std' is required for parser and compilation
 // interpreter can execute in `no_std` environment


### PR DESCRIPTION
Initial attempt at "catch-all" trait.

A problem with `downcast_ref::<T>()` was that it requires a concrete type `T` to be specified, which meant we couldn't downcast to `AsRef<[u8]>` or `TryInto<u64>`.

Changes:
- add a new module (`src/interpreter/type_cast.rs`) with unit tests
- add necessary lines to integrate `type_cast` into the main library

Closes #3 