### PR TITLE
refactor using blanket trait impl

### DIFF
--- a/src/interpreter/type_cast.rs
+++ b/src/interpreter/type_cast.rs
@@ -19,13 +19,9 @@ pub trait IntoPact<'a, I> {
     fn into_pact(self) -> Result<PactType<'a>, ()>;
 }
 
-/// Dummy structs
-struct Numbers;
-struct Strings;
-
 /// Impl for all types that implement fallible conversion into u64
 // FIXME: impl Into<u128> after this is implemented https://github.com/cennznet/pact/issues/1
-impl<'a, T: TryInto<u64> + Copy> IntoPact<'a, &Numbers> for T {
+impl<'a, T: TryInto<u64> + Copy> IntoPact<'a, &T> for T {
     fn into_pact(self) -> Result<PactType<'a>, ()> {
         let result: u64 = self.try_into().map_err(|_| ())?;
         Ok(PactType::Numeric(Numeric(result)))
@@ -33,7 +29,7 @@ impl<'a, T: TryInto<u64> + Copy> IntoPact<'a, &Numbers> for T {
 }
 
 /// Impl for all types that can be converted to &[u8]
-impl<'a, T: AsRef<[u8]> + ?Sized> IntoPact<'a, &Strings> for &'a T {
+impl<'a, T: AsRef<[u8]> + ?Sized> IntoPact<'a, &T> for &'a T {
     fn into_pact(self) -> Result<PactType<'a>, ()> {
         Ok(PactType::StringLike(StringLike(self.as_ref())))
     }

--- a/src/interpreter/type_cast.rs
+++ b/src/interpreter/type_cast.rs
@@ -19,9 +19,13 @@ pub trait IntoPact<'a, I> {
     fn into_pact(self) -> Result<PactType<'a>, ()>;
 }
 
+/// Dummy structs
+struct Numbers;
+struct Strings;
+
 /// Impl for all types that implement fallible conversion into u64
 // FIXME: impl Into<u128> after this is implemented https://github.com/cennznet/pact/issues/1
-impl<'a, T: TryInto<u64> + Copy> IntoPact<'a, &T> for T {
+impl<'a, T: TryInto<u64> + Copy> IntoPact<'a, &Numbers> for T {
     fn into_pact(self) -> Result<PactType<'a>, ()> {
         let result: u64 = self.try_into().map_err(|_| ())?;
         Ok(PactType::Numeric(Numeric(result)))
@@ -29,7 +33,7 @@ impl<'a, T: TryInto<u64> + Copy> IntoPact<'a, &T> for T {
 }
 
 /// Impl for all types that can be converted to &[u8]
-impl<'a, T: AsRef<[u8]> + ?Sized> IntoPact<'a, &T> for &'a T {
+impl<'a, T: AsRef<[u8]> + ?Sized> IntoPact<'a, &Strings> for &'a T {
     fn into_pact(self) -> Result<PactType<'a>, ()> {
         Ok(PactType::StringLike(StringLike(self.as_ref())))
     }

--- a/src/interpreter/type_cast.rs
+++ b/src/interpreter/type_cast.rs
@@ -46,6 +46,7 @@ mod tests {
             (1_u16.into_pact(), Ok(PactType::Numeric(Numeric(1)))),
             (2_u32.into_pact(), Ok(PactType::Numeric(Numeric(2)))),
             (3_u64.into_pact(), Ok(PactType::Numeric(Numeric(3)))),
+            (4_u128.into_pact(), Ok(PactType::Numeric(Numeric(4)))),
         ];
         for (lhs, rhs) in tests {
             assert_eq!(lhs, rhs);

--- a/src/interpreter/type_cast.rs
+++ b/src/interpreter/type_cast.rs
@@ -12,23 +12,26 @@
 // limitations under the License.
 
 use crate::interpreter::types::{Numeric, PactType, StringLike};
+use core::convert::TryInto;
 
 /// A blanket trait for conversion into PactType
 pub trait IntoPact<'a, I> {
-    fn into_pact(self) -> PactType<'a>;
+    fn into_pact(self) -> Result<PactType<'a>, ()>;
 }
 
-/// Impl for all types that implement lossless conversion into u64
-impl<'a, T: Into<u64> + Copy> IntoPact<'a, &T> for T {
-    fn into_pact(self) -> PactType<'a> {
-        PactType::Numeric(Numeric(Into::<u64>::into(self)))
+/// Impl for all types that implement fallible conversion into u64
+// FIXME: impl Into<u128> after this is implemented https://github.com/cennznet/pact/issues/1
+impl<'a, T: TryInto<u64> + Copy> IntoPact<'a, &T> for T {
+    fn into_pact(self) -> Result<PactType<'a>, ()> {
+        let result: u64 = self.try_into().map_err(|_| ())?;
+        Ok(PactType::Numeric(Numeric(result)))
     }
 }
 
 /// Impl for all types that can be converted to &[u8]
 impl<'a, T: AsRef<[u8]> + ?Sized> IntoPact<'a, &T> for &'a T {
-    fn into_pact(self) -> PactType<'a> {
-        PactType::StringLike(StringLike(self.as_ref()))
+    fn into_pact(self) -> Result<PactType<'a>, ()> {
+        Ok(PactType::StringLike(StringLike(self.as_ref())))
     }
 }
 
@@ -39,10 +42,10 @@ mod tests {
     #[test]
     fn it_converts_numeric() {
         let tests = vec![
-            (0_u8.into_pact(), PactType::Numeric(Numeric(0))),
-            (1_u16.into_pact(), PactType::Numeric(Numeric(1))),
-            (2_u32.into_pact(), PactType::Numeric(Numeric(2))),
-            (3_u64.into_pact(), PactType::Numeric(Numeric(3))),
+            (0_u8.into_pact(), Ok(PactType::Numeric(Numeric(0)))),
+            (1_u16.into_pact(), Ok(PactType::Numeric(Numeric(1)))),
+            (2_u32.into_pact(), Ok(PactType::Numeric(Numeric(2)))),
+            (3_u64.into_pact(), Ok(PactType::Numeric(Numeric(3)))),
         ];
         for (lhs, rhs) in tests {
             assert_eq!(lhs, rhs);
@@ -53,11 +56,11 @@ mod tests {
     fn it_converts_string_like() {
         assert_eq!(
             "test".into_pact(),
-            PactType::StringLike(StringLike(b"test")),
+            Ok(PactType::StringLike(StringLike(b"test"))),
         );
 
         let v: Vec<u8> = vec![116, 101, 115, 116];
-        assert_eq!(v.into_pact(), PactType::StringLike(StringLike(b"test")),);
+        assert_eq!(v.into_pact(), Ok(PactType::StringLike(StringLike(b"test"))),);
 
         // Assertion for fixed hash types
         let h32 = b"0x01";
@@ -70,14 +73,14 @@ mod tests {
         let h520 = b"0x012345678910111213141516171819202122232425262728293031323334353";
 
         let tests = vec![
-            (h32.into_pact(), PactType::StringLike(StringLike(h32))),
-            (h64.into_pact(), PactType::StringLike(StringLike(h64))),
-            (h128.into_pact(), PactType::StringLike(StringLike(h128))),
-            (h160.into_pact(), PactType::StringLike(StringLike(h160))),
-            (h256.into_pact(), PactType::StringLike(StringLike(h256))),
-            (h264.into_pact(), PactType::StringLike(StringLike(h264))),
-            (h512.into_pact(), PactType::StringLike(StringLike(h512))),
-            (h520.into_pact(), PactType::StringLike(StringLike(h520))),
+            (h32.into_pact(), Ok(PactType::StringLike(StringLike(h32)))),
+            (h64.into_pact(), Ok(PactType::StringLike(StringLike(h64)))),
+            (h128.into_pact(), Ok(PactType::StringLike(StringLike(h128)))),
+            (h160.into_pact(), Ok(PactType::StringLike(StringLike(h160)))),
+            (h256.into_pact(), Ok(PactType::StringLike(StringLike(h256)))),
+            (h264.into_pact(), Ok(PactType::StringLike(StringLike(h264)))),
+            (h512.into_pact(), Ok(PactType::StringLike(StringLike(h512)))),
+            (h520.into_pact(), Ok(PactType::StringLike(StringLike(h520)))),
         ];
         for (lhs, rhs) in tests {
             assert_eq!(lhs, rhs);
@@ -102,8 +105,8 @@ mod tests {
         let n64: <Bar as Foo>::Number64 = 20u64;
 
         let tests = vec![
-            (n32.into_pact(), PactType::Numeric(Numeric(10))),
-            (n64.into_pact(), PactType::Numeric(Numeric(20))),
+            (n32.into_pact(), Ok(PactType::Numeric(Numeric(10)))),
+            (n64.into_pact(), Ok(PactType::Numeric(Numeric(20)))),
         ];
         for (lhs, rhs) in tests {
             assert_eq!(lhs, rhs);
@@ -131,9 +134,18 @@ mod tests {
         let s3: <Bar as Foo>::Str = "test3".to_string();
 
         let tests = vec![
-            (s1.into_pact(), PactType::StringLike(StringLike(b"test1"))),
-            (s2.into_pact(), PactType::StringLike(StringLike(b"test2"))),
-            (s3.into_pact(), PactType::StringLike(StringLike(b"test3"))),
+            (
+                s1.into_pact(),
+                Ok(PactType::StringLike(StringLike(b"test1"))),
+            ),
+            (
+                s2.into_pact(),
+                Ok(PactType::StringLike(StringLike(b"test2"))),
+            ),
+            (
+                s3.into_pact(),
+                Ok(PactType::StringLike(StringLike(b"test3"))),
+            ),
         ];
         for (lhs, rhs) in tests {
             assert_eq!(lhs, rhs);

--- a/src/interpreter/type_cast.rs
+++ b/src/interpreter/type_cast.rs
@@ -18,19 +18,15 @@ pub trait IntoPact<'a, I> {
     fn into_pact(self) -> PactType<'a>;
 }
 
-/// Dummy structs
-struct Numbers;
-struct Strings;
-
 /// Impl for all types that implement lossless conversion into u64
-impl<'a, T: Into<u64> + Copy> IntoPact<'a, &Numbers> for T {
+impl<'a, T: Into<u64> + Copy> IntoPact<'a, &T> for T {
     fn into_pact(self) -> PactType<'a> {
         PactType::Numeric(Numeric(Into::<u64>::into(self)))
     }
 }
 
 /// Impl for all types that can be converted to &[u8]
-impl<'a, T: AsRef<[u8]> + ?Sized> IntoPact<'a, &Strings> for &'a T {
+impl<'a, T: AsRef<[u8]> + ?Sized> IntoPact<'a, &T> for &'a T {
     fn into_pact(self) -> PactType<'a> {
         PactType::StringLike(StringLike(self.as_ref()))
     }

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -14,7 +14,7 @@
 //!
 //! Primitive types in the pact interpreter.
 //!
-pub use crate::interpreter::type_cast::AnyTryInto;
+pub use crate::interpreter::type_cast::IntoPact;
 use bit_reverse::ParallelReverse;
 use std::vec::Vec;
 


### PR DESCRIPTION
Changes:
- remove Any
- add a blanket trait (`IntoPact`) whose method return `PactType` (not `Result`)
- add dummy structs (used to trick the compiler to ignore `conflicting trait implementations` [error](https://doc.rust-lang.org/error-index.html#E0119)
- impl the blanket trait with `Into<u64>` and `AsRef<[u8]>` trait bounds
- update tests accordingly
- expose the blanket trait

Closes #7