### PR TITLE
add a clippy step for ci & resolve clippy lints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,7 @@ jobs:
           name: setup
           command: |
             rustup install nightly
-            rustup component add rustfmt
-            rustup component add clippy
+            rustup component add rustfmt clippy
       - run:
           name: cargo check
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,8 @@ jobs:
           name: setup
           command: |
             rustup install nightly
-            rustup default nightly
             rustup component add rustfmt
-            rustup component add clippy || cargo install --git https://github.com/rust-lang/rust-clippy/ --force clippy
+            rustup component add clippy
       - run:
           name: cargo check
           command: |
@@ -34,8 +33,8 @@ jobs:
       - run:
           name: "Check 'no std' build"
           command: |
-            cargo --version --verbose
-            cargo check --no-default-features
+            cargo +nightly --version --verbose
+            cargo +nightly check --no-default-features
 workflows:
   version: 2
   run-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,12 +10,17 @@ jobs:
           command: |
             rustup install nightly
             rustup default nightly
-            rustup component add rustfmt
+            rustup component add rustfmt clippy
       - run:
           name: cargo check
           command: |
             cargo --version --verbose
             cargo check
+      - run:
+          name: cargo clippy
+          # FIXME remove "allow" after this issue is fixed: https://git.io/Je07b
+          command: |
+            cargo clippy -- --allow clippy::needless_lifetimes
       - run:
           name: cargo fmt
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,8 @@ jobs:
           command: |
             rustup install nightly
             rustup default nightly
-            rustup component add rustfmt clippy
+            rustup component add rustfmt
+            rustup component add clippy || cargo install --git https://github.com/rust-lang/rust-clippy/ --force clippy
       - run:
           name: cargo check
           command: |

--- a/src/compiler/data_table.rs
+++ b/src/compiler/data_table.rs
@@ -34,8 +34,8 @@ impl<'a> DataTable<'a> {
             t.encode(buf);
         }
     }
-    /// Decode a DataTable from `buf`.  
-    /// Return the DataTable and # of bytes read or error on failure.  
+    /// Decode a DataTable from `buf`.
+    /// Return the DataTable and # of bytes read or error on failure.
     pub fn decode(buf: &'a [u8]) -> Result<(Self, usize), &'static str> {
         let mut table = DataTable(Default::default());
         let mut offset: usize = 1;
@@ -45,7 +45,7 @@ impl<'a> DataTable<'a> {
             table.push(pact_type);
             offset += read;
         }
-        return Ok((table, offset));
+        Ok((table, offset))
     }
 }
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -89,7 +89,7 @@ pub fn compile<'a>(ir: &'a [ast::Node]) -> Result<Contract<'a>, CompileErr> {
     for node in ir.iter() {
         match node {
             ast::Node::InputDeclaration(idents) => {
-                for (index, ident) in idents.into_iter().enumerate() {
+                for (index, ident) in idents.iter().enumerate() {
                     compiler
                         .input_var_index
                         .insert(ident.to_string(), index as u8);
@@ -214,8 +214,7 @@ fn compile_conjunctive(conjunctive: &ast::Conjunctive) -> Result<OpCode, Compile
     Ok(match conjunctive {
         ast::Conjunctive::And => OpCode::AND,
         ast::Conjunctive::Or => OpCode::OR,
-    }
-    .into())
+    })
 }
 
 /// Compile a comparator AST node
@@ -226,8 +225,7 @@ fn compile_comparator(comparator: &ast::Comparator) -> Result<OpCode, CompileErr
         ast::Comparator::GreaterThanOrEqual => OpCode::GTE,
         ast::Comparator::LessThan => OpCode::LT,
         ast::Comparator::LessThanOrEqual => OpCode::LTE,
-    }
-    .into())
+    })
 }
 
 #[cfg(test)]

--- a/src/interpreter/types.rs
+++ b/src/interpreter/types.rs
@@ -49,7 +49,7 @@ impl<'a> PactType<'a> {
                 buf.push(1.swap_bits());
                 // only supporting 64-bit numeric here.
                 buf.push(8.swap_bits());
-                for b in n.0.to_le_bytes().into_iter() {
+                for b in n.0.to_le_bytes().iter() {
                     buf.push(b.swap_bits())
                 }
             }
@@ -85,7 +85,7 @@ impl<'a> PactType<'a> {
                 ])));
                 Ok((n, 10usize))
             }
-            _ => return Err("unsupported type ID"),
+            _ => Err("unsupported type ID"),
         }
     }
 }


### PR DESCRIPTION
The following lints are resolved (list is [here](https://rust-lang.github.io/rust-clippy/master/)):
- needless_return
- into_iter_on_array
- identity_conversion
- needless_borrow
