### PR TITLE
Feature/4 set membership

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,13 +139,13 @@ version = "0.1.0"
 dependencies = [
  "bit_reverse 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pest 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pest"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-trie 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -156,7 +156,7 @@ name = "pest_derive"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "pest 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_generator 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -165,7 +165,7 @@ name = "pest_generator"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "pest 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_meta 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -178,7 +178,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "pest 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -342,7 +342,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"
 "checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
-"checksum pest 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "933085deae3f32071f135d799d75667b63c8dc1f4537159756e3d4ceab41868c"
+"checksum pest 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e4fb201c5c22a55d8b24fef95f78be52738e5e1361129be1b5e862ecdb6894a"
 "checksum pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
 "checksum pest_generator 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "63120576c4efd69615b5537d3d052257328a4ca82876771d6944424ccfd9f646"
 "checksum pest_meta 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f249ea6de7c7b7aba92b4ff4376a994c6dbd98fd2166c89d5c4947397ecb574d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 bit_reverse = { version = "0.1.8", default-features = false }
 hashbrown =  { version = "0.6.0" }
-pest = { version = "2.1.1", optional = true }
+pest = { version = "2.1.2", optional = true }
 pest_derive = {version = "2.1.0", optional = true }
 
 [features]

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -197,7 +197,12 @@ fn eval_comparator(op: OpCode, lhs: &PactType, rhs: &PactType) -> Result<bool, I
         },
         (PactType::StringLike(l), PactType::StringLike(r)) => match op {
             OpCode::EQ => Ok(l == r),
-            OpCode::IN => Err(InterpErr::UnsupportedOpCode("IN is not supported yet")),
+            _ => Err(InterpErr::BadTypeOperation),
+        },
+        // List types are unsupported on LHS
+        (PactType::List(_), _) => Err(InterpErr::BadTypeOperation),
+        (l, PactType::List(r)) => match op {
+            OpCode::IN => Ok(r.contains(l)),
             _ => Err(InterpErr::BadTypeOperation),
         },
         _ => Err(InterpErr::TypeMismatch),

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -63,6 +63,8 @@ pub enum Comparator {
     GreaterThanOrEqual,
     LessThan,
     LessThanOrEqual,
+    // i.e set membership check: _a_ 'in' {1,2,3}
+    ElementOf,
 }
 
 /// A subject of a comparator (LHS / RHS).
@@ -76,8 +78,11 @@ pub enum Subject {
 /// A literal value, used in place for a comparator or on the RHS of a definition
 #[derive(Clone, Debug)]
 pub enum Value {
-    StringLike(String),
     Numeric(u64),
+    StringLike(String),
+    /// A homogenous list of `Value` nodes
+    /// While it is possible to nest lists with this definition, it is not supported semantically.
+    List(Vec<Value>),
 }
 
 pub type Identifier = String;

--- a/src/parser/grammar.pest
+++ b/src/parser/grammar.pest
@@ -29,23 +29,30 @@ must_not_be = { "must not be" }
 imperative = _{ must_be | must_not_be }
 
 // Comparators
+element_of = { "one of" }
 eq = { "equal to" }
 lt = { "less than" }
 lte = { "less than or equal to" }
 gt = { "greater than" }
 gte = { "greater than or equal to" }
-comparator = _{ eq | gte | gt | lte | lt }
+comparator = _{ eq | gte | gt | lte | lt | element_of }
 
 assertion = { subject ~ imperative ~ comparator ~ subject ~ (conjunction ~ assertion)? }
 definition = { "define" ~ identifier ~ "as" ~ value }
 
 // Variables
 subject = _{ value | identifier }
-value = { string | integer }
+value = { string | strings | integer | integers }
+ // one or more "," delimited `integer`
+integers = { list_open ~ integer ~ ("," ~ integer)* ~ list_close }
+// one or more ',' delimited `string`
+strings = { list_open ~ string ~ ("," ~ string)* ~ list_close }
 integer = @{ ASCII_DIGIT+ }
 string = { quote ~ ASCII_ALPHANUMERIC+ ~ quote }
 identifier = @{ dollar ~ ASCII_ALPHA+ ~ (ASCII_ALPHANUMERIC)* }
 dollar = _{ "$" }
 quote = _{ "\"" }
+list_open = _{ "[" }
+list_close = _{ "]" }
 
 WHITESPACE = _{ " " | "\t" | NEWLINE }

--- a/src/types/base.rs
+++ b/src/types/base.rs
@@ -31,8 +31,9 @@ pub struct Numeric(pub u64);
 #[cfg_attr(feature = "std", derive(Debug, PartialEq))]
 #[derive(Clone)]
 pub enum PactType<'a> {
-    StringLike(StringLike<'a>),
     Numeric(Numeric),
+    List(Vec<PactType<'a>>),
+    StringLike(StringLike<'a>),
 }
 
 impl<'a> PactType<'a> {
@@ -52,6 +53,7 @@ impl<'a> PactType<'a> {
                     buf.push(b.swap_bits())
                 }
             }
+            PactType::List(_) => panic!("unimplemented"),
         };
     }
     /// Decode a pact type from the given buffer

--- a/src/types/base.rs
+++ b/src/types/base.rs
@@ -28,8 +28,8 @@ pub struct StringLike<'a>(pub &'a [u8]);
 pub struct Numeric(pub u64);
 
 /// Over-arching pact type system
-#[cfg_attr(feature = "std", derive(Debug, PartialEq))]
-#[derive(Clone)]
+#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Clone, PartialEq)]
 pub enum PactType<'a> {
     Numeric(Numeric),
     List(Vec<PactType<'a>>),

--- a/tests/compiler_integration.rs
+++ b/tests/compiler_integration.rs
@@ -21,8 +21,10 @@ use pact::types::{Numeric, PactType, StringLike};
 fn it_compiles() {
     let ast = parser::parse(
         "
-          given parameters $a,$b
+          given parameters $a,$b,$user
+          define $trusted as [\"alice\", \"bob\"]
           $a must be less than or equal to 123 and $b must be equal to \"hello world\"
+          $user must be one of $trusted
         ",
     )
     .unwrap();
@@ -31,10 +33,12 @@ fn it_compiles() {
     println!("Data Table: {:?}", contract.data_table);
     println!("Bytecode: {:?}", contract.bytecode);
 
-    // The manually crafted input table
+    // The manually crafted input table.
+    // This would be populated with transaction parameters in real execution
     let input_table = &[
         PactType::Numeric(Numeric(5)),
         PactType::StringLike(StringLike("hello world".as_bytes())),
+        PactType::StringLike(StringLike("alice".as_bytes())),
     ];
     println!("Input Table: {:?}", input_table);
 

--- a/tests/parser_integration.rs
+++ b/tests/parser_integration.rs
@@ -45,3 +45,29 @@ fn it_parses() {
     .unwrap();
     println!("{:?}", ast);
 }
+
+#[test]
+fn it_parses_an_integer_list() {
+    let ast = parser::parse(
+        "
+      given parameters $charlie, $tango, $delta
+      define $test as 12345
+      5 must be one of [123, 5, 12, 100, 55]
+      \"hello world\" must be equal to \"dorem ipsum\"",
+    )
+    .unwrap();
+    println!("{:?}", ast);
+}
+
+#[test]
+fn it_parses_a_string_list() {
+    let ast = parser::parse(
+        "
+      given parameters $payee
+      define $trusted as [\"a\", \"b\", \"c\"]
+      $payee must be one of $trusted
+        ",
+    )
+    .unwrap();
+    println!("{:?}", ast);
+}


### PR DESCRIPTION
Implement the `IN` operation for set membership.
Introduces a new `PactType::List` variant

TODO:
- [ ] Implement codec for `PactType::List`
- [ ] Not sure if we should enforce PactType::List must be homogenous (either all Numeric or All StringLike)

Closes #4 