### PR TITLE
Implement IN operator and PactType::List

### DIFF
--- a/design/pact/codec.md
+++ b/design/pact/codec.md
@@ -19,9 +19,9 @@ length: 1 LE byte
 data: <length> LE bytes
 ```
 
-`List` structs are slightly more complex where the internals are another pact type.
+`List` structs contain a list of `PactType` structs.
 
-For example, a List of three strings would be encoded to:
+For example, a `List` of three `StringLike` structs are encoded to:
 
 ```
 type index: 2 = List

--- a/design/pact/codec.md
+++ b/design/pact/codec.md
@@ -1,6 +1,6 @@
 # Pact Binary Format v0 (codec)
-The pact binary format is 1 version byte, followed by static data section and trailling pact opcodes (bytecode).  
-`version | datatable | bytecode` or formally,  
+The pact binary format is 1 version byte, followed by static data section and trailling pact opcodes (bytecode).
+`version | datatable | bytecode` or formally,
 ```
 version:   1 LE byte
 datatable: DataTable (see datatable codec)
@@ -8,25 +8,45 @@ bytecode:  remaining LE bytes
 ```
 
 # PactType Codec
-Codec spec for `PactType` structs  
+Codec spec for `PactType` structs
 
 ```
 type index: 1 LE byte
     0 = StringLike
     1 = Numeric
+    2 = List
 length: 1 LE byte
 data: <length> LE bytes
 ```
 
-# DataTable codec
-Codec spec for the pact binary datatable.  
-A DataTable is simply a list of `PactType`s and length prefix.  
-Its encoded form is a concatenation of encoded `PactType`s  
-Therefore the process of decoding a `DataTable` from an input buffer is as follows:  
-1) Read the length byte  
-2) Decode _l_ PactType's from the input, return _bytes read_, move the offset into the input buffer _bytes read_  
-2) Repeat until end of input (success) or failure  
+`List` structs are slightly more complex where the internals are another pact type.
 
-Encoding is simply:  
+For example, a List of three strings would be encoded to:
+
+```
+type index: 2 = List
+length: 17
+data:
+    type index: 0 = StringLike
+    length: 4
+    data: 'know'
+    type index: 0 = StringLike
+    length: 3
+    data: 'the'
+    type index: 0 = StringLike
+    length: 4
+    data: 'game'
+```
+
+# DataTable codec
+Codec spec for the pact binary datatable.
+A DataTable is simply a list of `PactType`s and length prefix.
+Its encoded form is a concatenation of encoded `PactType`s
+Therefore the process of decoding a `DataTable` from an input buffer is as follows:
+1) Read the length byte
+2) Decode _l_ PactType's from the input, return _bytes read_, move the offset into the input buffer _bytes read_
+2) Repeat until end of input (success) or failure
+
+Encoding is simply:
 1) push the length byte _l_
-2) push _l_ encoded `PactType`s to the buffer  
+2) push _l_ encoded `PactType`s to the buffer

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -27,6 +27,7 @@ pub enum CompileErr {
     UndeclaredVar(ast::Identifier),
     /// A parameter with the same identifier has already been declared
     Redeclared,
+    InvalidListElement,
 }
 
 /// Compile a pact contract AST into bytecode
@@ -67,6 +68,19 @@ pub fn compile(ir: &[ast::Node]) -> Result<Contract, CompileErr> {
                 let v = match value {
                     ast::Value::Numeric(n) => PactType::Numeric(Numeric(*n)),
                     ast::Value::StringLike(s) => PactType::StringLike(StringLike(s.as_bytes())),
+                    ast::Value::List(l) => {
+                        let mut list = Vec::<PactType>::with_capacity(l.len());
+                        for element in l {
+                            list.push(
+                                match element {
+                                    ast::Value::Numeric(n) => PactType::Numeric(Numeric(*n)),
+                                    ast::Value::StringLike(s) => PactType::StringLike(StringLike(s.as_bytes())),
+                                    _ => return Err(CompileErr::InvalidListElement)
+                                }
+                            )
+                        }
+                        PactType::List(list)
+                    }
                 };
                 compiler.data_table.push(v)
             }
@@ -145,6 +159,7 @@ impl<'a> Compiler<'a> {
                 let v = match value {
                     ast::Value::Numeric(n) => PactType::Numeric(Numeric(*n)),
                     ast::Value::StringLike(s) => PactType::StringLike(StringLike(s.as_bytes())),
+                    ast::Value::List(_) => panic!("Invalid subject"),
                 };
                 self.data_table.push(v);
                 Ok(OpCode::LD_USER((self.data_table.len() as u8) - 1))
@@ -179,5 +194,6 @@ fn compile_comparator(comparator: &ast::Comparator) -> Result<OpCode, CompileErr
         ast::Comparator::GreaterThanOrEqual => OpCode::GTE,
         ast::Comparator::LessThan => OpCode::LT,
         ast::Comparator::LessThanOrEqual => OpCode::LTE,
+        ast::Comparator::OneOf => OpCode::IN,
     })
 }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -71,13 +71,13 @@ pub fn compile(ir: &[ast::Node]) -> Result<Contract, CompileErr> {
                     ast::Value::List(l) => {
                         let mut list = Vec::<PactType>::with_capacity(l.len());
                         for element in l {
-                            list.push(
-                                match element {
-                                    ast::Value::Numeric(n) => PactType::Numeric(Numeric(*n)),
-                                    ast::Value::StringLike(s) => PactType::StringLike(StringLike(s.as_bytes())),
-                                    _ => return Err(CompileErr::InvalidListElement)
+                            list.push(match element {
+                                ast::Value::Numeric(n) => PactType::Numeric(Numeric(*n)),
+                                ast::Value::StringLike(s) => {
+                                    PactType::StringLike(StringLike(s.as_bytes()))
                                 }
-                            )
+                                _ => return Err(CompileErr::InvalidListElement),
+                            })
                         }
                         PactType::List(list)
                     }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -200,9 +200,12 @@ fn eval_comparator(op: OpCode, lhs: &PactType, rhs: &PactType) -> Result<bool, I
         },
         (PactType::StringLike(l), PactType::StringLike(r)) => match op {
             OpCode::EQ => Ok(l == r),
-            OpCode::IN => Err(InterpErr::UnsupportedOpCode("IN is not supported yet")),
             _ => Err(InterpErr::BadTypeOperation),
         },
+        (l, PactType::List(r)) => match op {
+            OpCode::IN => Ok(r.contains(l)),
+            _ => Err(InterpErr::BadTypeOperation),
+        }
         _ => Err(InterpErr::TypeMismatch),
     }
 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -202,10 +202,13 @@ fn eval_comparator(op: OpCode, lhs: &PactType, rhs: &PactType) -> Result<bool, I
             OpCode::EQ => Ok(l == r),
             _ => Err(InterpErr::BadTypeOperation),
         },
+        (PactType::List(_), _) => match op {
+            _ => Err(InterpErr::BadTypeOperation),
+        },
         (l, PactType::List(r)) => match op {
             OpCode::IN => Ok(r.contains(l)),
             _ => Err(InterpErr::BadTypeOperation),
-        }
+        },
         _ => Err(InterpErr::TypeMismatch),
     }
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -82,7 +82,7 @@ pub enum Subject {
 pub enum Value {
     StringLike(String),
     Numeric(u64),
-    List(Vec<Value>)
+    List(Vec<Value>),
 }
 
 pub type Identifier = String;

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -66,6 +66,7 @@ pub enum Comparator {
     GreaterThanOrEqual,
     LessThan,
     LessThanOrEqual,
+    OneOf,
 }
 
 /// A subject of a comparator (LHS / RHS).
@@ -81,6 +82,7 @@ pub enum Subject {
 pub enum Value {
     StringLike(String),
     Numeric(u64),
+    List(Vec<Value>)
 }
 
 pub type Identifier = String;

--- a/src/parser/grammar.pest
+++ b/src/parser/grammar.pest
@@ -38,18 +38,19 @@ lt = { "less than" }
 lte = { "less than or equal to" }
 gt = { "greater than" }
 gte = { "greater than or equal to" }
-comparator = _{ eq | gte | gt | lte | lt }
-
+element_of = { "one of" }
+comparator = _{ eq | gte | gt | lte | lt | element_of }
 assertion = { subject ~ imperative ~ comparator ~ subject ~ (conjunction ~ assertion)? }
 definition = { "define" ~ identifier ~ "as" ~ value }
 
 // Variables
 subject = _{ value | identifier }
-value = { string | integer }
+value = { string | integer | strings | integers }
 integer = @{ ASCII_DIGIT+ }
 string = { quote ~ ASCII_ALPHANUMERIC+ ~ quote }
+integers = { "[" ~ integer ~ ("," ~ integer)* ~ "]" }
+strings = { "[" ~ string ~ ("," ~ string)* ~ "]" }
 identifier = @{ dollar ~ ASCII_ALPHA+ ~ (ASCII_ALPHANUMERIC)* }
 dollar = _{ "$" }
 quote = _{ "\"" }
-
 WHITESPACE = _{ " " | "\t" | NEWLINE }

--- a/src/parser/grammar.pest
+++ b/src/parser/grammar.pest
@@ -38,8 +38,8 @@ lt = { "less than" }
 lte = { "less than or equal to" }
 gt = { "greater than" }
 gte = { "greater than or equal to" }
-element_of = { "one of" }
-comparator = _{ eq | gte | gt | lte | lt | element_of }
+one_of = { "one of" }
+comparator = _{ eq | gte | gt | lte | lt | one_of }
 assertion = { subject ~ imperative ~ comparator ~ subject ~ (conjunction ~ assertion)? }
 definition = { "define" ~ identifier ~ "as" ~ value }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -23,7 +23,7 @@ use pest::Parser;
 #[grammar = "parser/grammar.pest"]
 pub struct PactParser;
 
-/// Attempt to parse the given `source` string as pact code.  
+/// Attempt to parse the given `source` string as pact code.
 /// Returns an AST on success, otherwise the relevant error
 pub fn parse(source: &str) -> Result<Vec<ast::Node>, Error<Rule>> {
     let mut ast: Vec<ast::Node> = Default::default();
@@ -92,6 +92,7 @@ fn build_assertion(pair: pest::iterators::Pair<Rule>) -> ast::Assertion {
         Rule::gte => ast::Comparator::GreaterThanOrEqual,
         Rule::lt => ast::Comparator::LessThan,
         Rule::lte => ast::Comparator::LessThanOrEqual,
+        Rule::element_of => ast::Comparator::OneOf,
         _ => panic!("unreachable"),
     };
     println!("comparator: {:?}", comparator);
@@ -129,6 +130,22 @@ fn build_value(pair: pest::iterators::Pair<Rule>) -> ast::Value {
             ast::Value::StringLike(value.as_str().trim_matches('"').into())
         }
         Rule::integer => ast::Value::Numeric(value.as_str().parse().unwrap()),
+        Rule::strings => {
+            ast::Value::List(value.into_inner()
+                .map(|s| ast::Value::StringLike(
+                    s.as_str().trim_matches('"').into()
+                ))
+                .collect()
+            )
+        }
+        Rule::integers => {
+            ast::Value::List(value.into_inner()
+                .map(|n| ast::Value::Numeric(
+                    n.as_str().parse().unwrap()
+                ))
+                .collect()
+            )
+        }
         _ => panic!("unreachable"),
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -92,7 +92,7 @@ fn build_assertion(pair: pest::iterators::Pair<Rule>) -> ast::Assertion {
         Rule::gte => ast::Comparator::GreaterThanOrEqual,
         Rule::lt => ast::Comparator::LessThan,
         Rule::lte => ast::Comparator::LessThanOrEqual,
-        Rule::element_of => ast::Comparator::OneOf,
+        Rule::one_of => ast::Comparator::OneOf,
         _ => panic!("unreachable"),
     };
     println!("comparator: {:?}", comparator);

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -130,22 +130,18 @@ fn build_value(pair: pest::iterators::Pair<Rule>) -> ast::Value {
             ast::Value::StringLike(value.as_str().trim_matches('"').into())
         }
         Rule::integer => ast::Value::Numeric(value.as_str().parse().unwrap()),
-        Rule::strings => {
-            ast::Value::List(value.into_inner()
-                .map(|s| ast::Value::StringLike(
-                    s.as_str().trim_matches('"').into()
-                ))
-                .collect()
-            )
-        }
-        Rule::integers => {
-            ast::Value::List(value.into_inner()
-                .map(|n| ast::Value::Numeric(
-                    n.as_str().parse().unwrap()
-                ))
-                .collect()
-            )
-        }
+        Rule::strings => ast::Value::List(
+            value
+                .into_inner()
+                .map(|s| ast::Value::StringLike(s.as_str().trim_matches('"').into()))
+                .collect(),
+        ),
+        Rule::integers => ast::Value::List(
+            value
+                .into_inner()
+                .map(|n| ast::Value::Numeric(n.as_str().parse().unwrap()))
+                .collect(),
+        ),
         _ => panic!("unreachable"),
     }
 }

--- a/src/types/base.rs
+++ b/src/types/base.rs
@@ -36,6 +36,7 @@ pub struct Numeric(pub u64);
 pub enum PactType<'a> {
     StringLike(StringLike<'a>),
     Numeric(Numeric),
+    List(Vec<PactType<'a>>),
 }
 
 impl<'a> PactType<'a> {
@@ -54,6 +55,9 @@ impl<'a> PactType<'a> {
                 for b in n.0.to_le_bytes().iter() {
                     buf.push(b.swap_bits())
                 }
+            }
+            PactType::List(_) => {
+                panic!("todo");
             }
         };
     }

--- a/src/types/base.rs
+++ b/src/types/base.rs
@@ -174,6 +174,23 @@ mod tests {
     }
 
     #[test]
+    fn it_encodes_numeric_list() {
+        let l = PactType::List(vec![
+            PactType::Numeric(Numeric(0x0123456789abcdef)),
+            PactType::Numeric(Numeric(0xfedcba9876543210)),
+        ]);
+        let buf: &mut Vec<u8> = &mut Vec::new();
+        l.encode(buf);
+
+        let list_header: Vec<u8> = vec![2, 20];
+        let item_0: Vec<u8> = vec![1, 8, 0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01];
+        let item_1: Vec<u8> = vec![1, 8, 0x10, 0x32, 0x54, 0x76, 0x98, 0xba, 0xdc, 0xfe];
+        let mut expected: Vec<u8> = [list_header, item_0, item_1].concat();
+        expected = expected.into_iter().map(|b| b.swap_bits()).collect(); // convert to LE bit orders
+        assert_eq!(buf, &expected);
+    }
+
+    #[test]
     fn it_decodes_string_like() {
         let mut buf = vec![0, 11];
         buf = buf.into_iter().map(|b| b.swap_bits()).collect(); // convert to LE bit orders

--- a/src/types/base.rs
+++ b/src/types/base.rs
@@ -62,7 +62,7 @@ impl<'a> PactType<'a> {
                     match element {
                         PactType::StringLike(_) => element.encode(&mut buf_elements),
                         PactType::Numeric(_) => element.encode(&mut buf_elements),
-                        _ => {}, // element not supported
+                        _ => {} // element not supported
                     }
                 }
 
@@ -125,7 +125,8 @@ impl<'a> PactType<'a> {
                 while remaining_length > 0 {
                     let (new_value, offset) = Self::decode(&buf[read_offset..])?;
                     read_offset = read_offset + offset;
-                    remaining_length = remaining_length.checked_sub(offset)
+                    remaining_length = remaining_length
+                        .checked_sub(offset)
                         .ok_or("list length overflow")?;
                     values.push(new_value);
                 }
@@ -244,7 +245,8 @@ mod tests {
             b"and so".to_vec(),
             str3_header,
             b"do I".to_vec(),
-        ].concat();
+        ]
+        .concat();
 
         let (list_type, bytes_read) = PactType::decode(&buf).expect("it decodes");
 
@@ -255,10 +257,7 @@ mod tests {
             PactType::StringLike(StringLike(b"do I")),
         ]);
 
-        assert_eq!(
-            list_type,
-            expected,
-        );
+        assert_eq!(list_type, expected,);
 
         assert_eq!(bytes_read, 37usize);
     }
@@ -274,7 +273,11 @@ mod tests {
             vec![0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef],
             num_header,
             vec![0xfe, 0xed, 0xfe, 0xed, 0xfe, 0xed, 0xfe, 0xed],
-        ].concat().into_iter().map(|b| b.swap_bits()).collect();
+        ]
+        .concat()
+        .into_iter()
+        .map(|b| b.swap_bits())
+        .collect();
 
         let (list_type, bytes_read) = PactType::decode(&buf).expect("it decodes");
 
@@ -283,10 +286,7 @@ mod tests {
             PactType::Numeric(Numeric(0xedfe_edfe_edfe_edfe)),
         ]);
 
-        assert_eq!(
-            list_type,
-            expected,
-        );
+        assert_eq!(list_type, expected,);
 
         assert_eq!(bytes_read, 22usize);
     }
@@ -298,7 +298,11 @@ mod tests {
             list_header,
             vec![1, 8],
             vec![0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef],
-        ].concat().into_iter().map(|b| b.swap_bits()).collect();
+        ]
+        .concat()
+        .into_iter()
+        .map(|b| b.swap_bits())
+        .collect();
 
         assert_eq!(PactType::decode(&buf), Err("type length > buffer length"));
 
@@ -307,7 +311,11 @@ mod tests {
             list_header,
             vec![1, 8],
             vec![0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef],
-        ].concat().into_iter().map(|b| b.swap_bits()).collect();
+        ]
+        .concat()
+        .into_iter()
+        .map(|b| b.swap_bits())
+        .collect();
 
         assert_eq!(PactType::decode(&buf), Err("list length overflow"));
     }
@@ -331,6 +339,26 @@ mod tests {
     #[test]
     #[should_panic(expected = "implementation only supports 64-bit numerics")]
     fn it_fails_with_u128_numeric() {
-        PactType::decode(&[1.swap_bits(), 16.swap_bits(), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap();
+        PactType::decode(&[
+            1.swap_bits(),
+            16.swap_bits(),
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ])
+        .unwrap();
     }
 }

--- a/src/types/base.rs
+++ b/src/types/base.rs
@@ -31,8 +31,8 @@ pub struct StringLike<'a>(pub &'a [u8]);
 pub struct Numeric(pub u64);
 
 /// Over-arching pact type system
-#[cfg_attr(feature = "std", derive(Debug, PartialEq))]
-#[derive(Clone)]
+#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Clone, PartialEq)]
 pub enum PactType<'a> {
     StringLike(StringLike<'a>),
     Numeric(Numeric),
@@ -57,7 +57,7 @@ impl<'a> PactType<'a> {
                 }
             }
             PactType::List(l) => {
-                let mut buf_elements: Vec<u8> = vec![];
+                let mut buf_elements: Vec<u8> = Vec::<u8>::default();
                 for element in l {
                     match element {
                         PactType::StringLike(_) => element.encode(&mut buf_elements),
@@ -119,7 +119,7 @@ impl<'a> PactType<'a> {
                 Ok((n, 10usize))
             }
             2 => {
-                let mut values: Vec<PactType> = vec![];
+                let mut values: Vec<PactType> = Vec::<PactType>::default();
                 let mut remaining_length = data_length;
 
                 while remaining_length > 0 {

--- a/tests/codec_integration.rs
+++ b/tests/codec_integration.rs
@@ -61,15 +61,15 @@ fn contract_binary_format_malformed_data_table() {
         Err(BinaryFormatErr::MalformedDataTable("missing type ID byte"))
     );
 
-    let mut bad_type_id = vec![0, 0b1000_0000, 0b0000_0001, 0b0000_0001];
+    let mut bad_type_id = vec![0, 0b1000_0000, 0b0000_0001, 0b0000_0000];
     assert_eq!(
         Contract::decode(&mut bad_type_id),
         Err(BinaryFormatErr::MalformedDataTable("unsupported type ID"))
     );
 
-    let mut numeric_too_large = vec![0, 0b1000_0000, 0b1000_0000, 0b0000_1111];
+    let mut numeric_too_small = vec![0, 0b1000_0000, 0b1000_0000, 0b0100_0000, 0, 0];
     assert_eq!(
-        Contract::decode(&mut numeric_too_large),
+        Contract::decode(&mut numeric_too_small),
         Err(BinaryFormatErr::MalformedDataTable(
             "implementation only supports 64-bit numerics"
         ))

--- a/tests/compiler_integration.rs
+++ b/tests/compiler_integration.rs
@@ -52,4 +52,3 @@ fn it_compiles() {
     println!("Result: {:?}", result);
     assert!(result.unwrap());
 }
-

--- a/tests/compiler_integration.rs
+++ b/tests/compiler_integration.rs
@@ -26,8 +26,10 @@ use pact::types::{Numeric, PactType, StringLike};
 fn it_compiles() {
     let ast = parser::parse(
         "
-          given parameters $a,$b
+          given parameters $a,$b,$user
+          define $trusted as [\"Rick Astley\", \"bob\"]
           $a must be less than or equal to 123 and $b must be equal to \"hello world\"
+          $user must be one of $trusted
         ",
     )
     .unwrap();
@@ -37,9 +39,11 @@ fn it_compiles() {
     println!("Bytecode: {:?}", contract.bytecode);
 
     // The manually crafted input table
+    // In normal execution, this contains the transaction arguments
     let input_table = &[
         PactType::Numeric(Numeric(5)),
         PactType::StringLike(StringLike("hello world".as_bytes())),
+        PactType::StringLike(StringLike("Rick Astley".as_bytes())),
     ];
     println!("Input Table: {:?}", input_table);
 

--- a/tests/compiler_integration.rs
+++ b/tests/compiler_integration.rs
@@ -52,3 +52,4 @@ fn it_compiles() {
     println!("Result: {:?}", result);
     assert!(result.unwrap());
 }
+

--- a/tests/interpreter_integration.rs
+++ b/tests/interpreter_integration.rs
@@ -444,3 +444,18 @@ fn it_does_a_gte_comparison_evaluates_false() {
 
     assert_eq!(result, Ok(false));
 }
+
+#[test]
+fn it_does_an_in_comparison() {
+    let result = interpreter::interpret(
+        &[
+            PactType::Numeric(Numeric(2)), PactType::Numeric(Numeric(5))
+        ],
+        &[
+            PactType::List([PactType::Numeric(Numeric(1)), PactType::Numeric(Numeric(2))].to_vec())
+        ],
+        &[OpCode::IN.into(), 0, 0, 1, 0],
+    );
+
+    assert_eq!(result, Ok(true));
+}

--- a/tests/parser_integration.rs
+++ b/tests/parser_integration.rs
@@ -50,3 +50,35 @@ fn it_parses() {
     .unwrap();
     println!("{:?}", ast);
 }
+
+#[test]
+fn it_parses_an_integer_list() {
+    let _ = parser::parse(
+        "given parameters $charlie, $tango, $delta 1337 must be one of [1, 2, 3, 4, 5]"
+    )
+    .unwrap();
+
+    let _ = parser::parse(
+        "
+      given parameters $charlie, $tango, $delta
+      define $list as [1, 2, 3, 4, 5]
+      $delta must be one of $list"
+    )
+    .unwrap();
+}
+
+#[test]
+fn it_parses_a_string_list() {
+    let _ = parser::parse(
+        "given parameters $rick, $astley \"Never\" must be one of [\"Never\", \"gonna\"]"
+    )
+    .unwrap();
+
+    let _ = parser::parse(
+      "
+      given parameters $rick, $astley
+      define $list as [\"You know\", \"the rules\", \"and so do I\"]
+      $rick must be one of $list"
+    )
+    .unwrap();
+}

--- a/tests/parser_integration.rs
+++ b/tests/parser_integration.rs
@@ -54,7 +54,7 @@ fn it_parses() {
 #[test]
 fn it_parses_an_integer_list() {
     let _ = parser::parse(
-        "given parameters $charlie, $tango, $delta 1337 must be one of [1, 2, 3, 4, 5]"
+        "given parameters $charlie, $tango, $delta 1337 must be one of [1, 2, 3, 4, 5]",
     )
     .unwrap();
 
@@ -62,7 +62,7 @@ fn it_parses_an_integer_list() {
         "
       given parameters $charlie, $tango, $delta
       define $list as [1, 2, 3, 4, 5]
-      $delta must be one of $list"
+      $delta must be one of $list",
     )
     .unwrap();
 }
@@ -70,15 +70,15 @@ fn it_parses_an_integer_list() {
 #[test]
 fn it_parses_a_string_list() {
     let _ = parser::parse(
-        "given parameters $rick, $astley \"Never\" must be one of [\"Never\", \"gonna\"]"
+        "given parameters $rick, $astley \"Never\" must be one of [\"Never\", \"gonna\"]",
     )
     .unwrap();
 
     let _ = parser::parse(
-      "
+        "
       given parameters $rick, $astley
       define $list as [\"You know\", \"the rules\", \"and so do I\"]
-      $rick must be one of $list"
+      $rick must be one of $list",
     )
     .unwrap();
 }

--- a/tests/parser_integration.rs
+++ b/tests/parser_integration.rs
@@ -82,3 +82,15 @@ fn it_parses_a_string_list() {
     )
     .unwrap();
 }
+
+#[test]
+#[should_panic]
+fn it_fails_when_parsing_a_mixed_list() {
+    let _ = parser::parse(
+        "
+      given parameters $rick, $astley
+      define $list as [\"Your hearts been aching but youre\", 2, \"shy to say it\"]
+      $rick must be one of $list",
+    )
+    .unwrap();
+}


### PR DESCRIPTION
This PR implements the IN operator for new PactType::List.

## Changes

* IN operator implemented
* PactType::List added
  * Can hold a list of PactType::StringLike or PactType::Numeric
* Docs Updated

## Concerns

* PactType::List could potentially contain a mix of Numeric and StringLike. 
  * This is prevented at the interpreter
  * For now, I figured the most robust thing to do is still decode mixed lists and let the operator work across them.
* This duplicates PR https://github.com/cennznet/pact/pull/19, but includes decode/encode

Closes #4